### PR TITLE
Make it possible to skip nfc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open http://localhost:1234.
 
 ## Troubleshooting
 
-* If the server hangs after the printout `reader:starting` it is most likely related to missing NFC drivers. You can skip using NFC by passing a `--no-nfc` flag when starting the server.
+* If the server hangs after the printout `reader:starting` it is most likely related to missing NFC drivers. You can skip using NFC by passing a `--disable-nfc` flag when starting the server.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm start
 
 Open http://localhost:1234.
 
+## Troubleshooting
+
+* If the server hangs after the printout `reader:starting` it is most likely related to missing NFC drivers. You can skip using NFC by passing a `--no-nfc` flag when starting the server.
+
 ## TODO
 
 ### Features

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const ant = require('./sensors/ant');
 
 const activeGames = [];
 
-if (process.argv[2] === '--no-nfc') {
+if (process.argv.indexOf('--disable-nfc') > -1) {
   console.log('reader:skipped');
 } else {
   const nfc = require('./sensors/nfc'); // eslint-disable-line global-require

--- a/server/index.js
+++ b/server/index.js
@@ -3,18 +3,23 @@ const games = require('./db/games');
 const entries = require('./db/entries');
 const ws = require('./ws');
 const http = require('./http');
-const nfc = require('./sensors/nfc');
 const ant = require('./sensors/ant');
 
 const activeGames = [];
 
-nfc.on('scan', async ({ uid }) => {
-  let user = players.get({ cardid: uid });
-  if (!user) {
-    user = players.create({ cardid: uid });
-  }
-  ws.send('player:scanned', user);
-});
+if (process.argv[2] === '--no-nfc') {
+  console.log('reader:skipped');
+} else {
+  const nfc = require('./sensors/nfc'); // eslint-disable-line global-require
+
+  nfc.on('scan', async ({ uid }) => {
+    let user = players.get({ cardid: uid });
+    if (!user) {
+      user = players.create({ cardid: uid });
+    }
+    ws.send('player:scanned', user);
+  });
+}
 
 ant.on('tick', ({ speed, cadence, power }) => {
   console.log('ant:tick', power);

--- a/server/sensors/nfc.js
+++ b/server/sensors/nfc.js
@@ -1,7 +1,18 @@
 const { NFC } = require('nfc-pcsc');
 
 const listeners = [];
-const nfc = new NFC();
+
+const logger = {
+  log: (...args) => (console.log(args)),
+  debug: (...args) => (console.log(args)),
+  info: (...args) => (console.log(args)),
+  warn: (...args) => (console.log(args)),
+  error: (...args) => (console.log(args)),
+};
+
+console.log('reader:starting');
+const nfc = new NFC(logger);
+console.log('reader:started');
 
 nfc.on('reader', (reader) => {
   console.log('reader:attached');

--- a/server/sensors/nfc.js
+++ b/server/sensors/nfc.js
@@ -2,16 +2,8 @@ const { NFC } = require('nfc-pcsc');
 
 const listeners = [];
 
-const logger = {
-  log: (...args) => (console.log(args)),
-  debug: (...args) => (console.log(args)),
-  info: (...args) => (console.log(args)),
-  warn: (...args) => (console.log(args)),
-  error: (...args) => (console.log(args)),
-};
-
 console.log('reader:starting');
-const nfc = new NFC(logger);
+const nfc = new NFC();
 console.log('reader:started');
 
 nfc.on('reader', (reader) => {


### PR DESCRIPTION
It is not possible to start the server (on Windows atleast) without having NFC drivers installed since the constructor for `pcsclite` hangs. This PR adds a `--no-nfc` flag to be passed to the server to disable the NFC support. By default it is still enabled.