### PR TITLE
Add idle overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,7 +1791,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
       "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       }
@@ -1931,8 +1930,30 @@
     "@types/node": {
       "version": "10.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.5.tgz",
-      "integrity": "sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw==",
-      "dev": true
+      "integrity": "sha512-GzdHjq3t3eGLMv92Al90Iq+EoLL+86mPfQhuglbBFO7HiLdC/rkt+zrzJJumAiBF6nsrBWhou22rPW663AAyFw=="
+    },
+    "@types/prop-types": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
+      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
+    },
+    "@types/react": {
+      "version": "16.7.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.7.6.tgz",
+      "integrity": "sha512-QBUfzftr/8eg/q3ZRgf/GaDP6rTYc7ZNem+g4oZM38C9vXyV8AWRWaTQuW5yCoZTsfHrN7b3DeEiUnqH9SrnpA==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
+      "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
+      "requires": {
+        "@types/node": "*",
+        "@types/react": "*"
+      }
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -2467,6 +2488,11 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2676,6 +2702,11 @@
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
+    },
+    "callbag-subscribe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/callbag-subscribe/-/callbag-subscribe-1.5.0.tgz",
+      "integrity": "sha512-nlojg2L0AX4MI3IBxUMBE9OyrfBGFvCqeiapDCXLwl2sory1/Z0HWNQnGR/9Gd7EcpRbyRWTrLVB53lW6EjAdA=="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -3222,6 +3253,15 @@
         }
       }
     },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
     "css-select": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
@@ -3244,7 +3284,6 @@
       "version": "1.0.0-alpha.28",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
-      "dev": true,
       "requires": {
         "mdn-data": "~1.1.0",
         "source-map": "^0.5.3"
@@ -3825,6 +3864,14 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+      "requires": {
+        "stackframe": "^1.0.4"
+      }
+    },
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
@@ -4387,6 +4434,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastest-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4549,14 +4601,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4571,20 +4621,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4701,8 +4748,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4714,7 +4760,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4729,7 +4774,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4737,14 +4781,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4763,7 +4805,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4844,8 +4885,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4857,7 +4897,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4979,7 +5018,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5168,7 +5206,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5790,6 +5828,11 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5854,6 +5897,15 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inline-style-prefixer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
+      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
+      "requires": {
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "6.2.0",
@@ -6203,8 +6255,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "js-base64": {
       "version": "2.4.9",
@@ -6464,8 +6515,7 @@
     "mdn-data": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true
+      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
     },
     "memoize-one": {
       "version": "4.0.3",
@@ -6616,6 +6666,28 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
       "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+    },
+    "nano-css": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-3.4.0.tgz",
+      "integrity": "sha512-75LqVARJoJDMGlRpRA8LtzlU8NxkxqkCR67DZgk0LP7tsglfjCFdNJcG4NNEDLLeLvCdnhyljdn54wAVWHoEeg==",
+      "requires": {
+        "css-tree": "^1.0.0-alpha.28",
+        "csstype": "^2.5.5",
+        "fastest-stable-stringify": "^1.0.1",
+        "inline-style-prefixer": "^4.0.0",
+        "rtl-css-js": "^1.9.0",
+        "sourcemap-codec": "^1.4.1",
+        "stacktrace-js": "^2.0.0",
+        "stylis": "3.5.0"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "3.5.0",
+          "resolved": "http://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
+          "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+        }
+      }
     },
     "nanoid": {
       "version": "2.0.0",
@@ -9019,10 +9091,31 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-use": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-4.10.0.tgz",
+      "integrity": "sha512-9ICIardfYV2qFQICGtgqBwY9PVGCzG0jfXH5Mdf4o1Exg1LwBoTS6v4MyNBYrWUaa4pkZvw8N2Z3IVuNbK2iMg==",
+      "requires": {
+        "@types/react": "^16.4.18",
+        "@types/react-dom": "^16.0.9",
+        "nano-css": "^3.4.0",
+        "react-wait": "^0.3.0",
+        "rebound": "^0.1.0",
+        "throttle-debounce": "^2.0.1",
+        "ts-easing": "^0.1.0",
+        "use-callbag": "^0.1.2",
+        "use-onclickoutside": "^0.1.0"
+      }
+    },
     "react-use-promise": {
       "version": "0.0.0-alpha.1",
       "resolved": "https://registry.npmjs.org/react-use-promise/-/react-use-promise-0.0.0-alpha.1.tgz",
       "integrity": "sha512-/F2n1Nh9JEC0KRwXD7HxI7jmGbduDAHA4PtOxCErBJ/yda7EUkOoe7Yp1gQCSRPBoEwMtin98FlDhi31knKzkg=="
+    },
+    "react-wait": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/react-wait/-/react-wait-0.3.0.tgz",
+      "integrity": "sha512-kB5x/kMKWcn0uVr9gBdNz21/oGbQwEQnF3P9p6E9yLfJ9DRcKS0fagbgYMFI0YFOoyKDj+2q6Rwax0kTYJF37g=="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -9080,6 +9173,11 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
+    },
+    "rebound": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rebound/-/rebound-0.1.0.tgz",
+      "integrity": "sha1-BjjGGpNma7UVpYoD4c+zQCHoi3I="
     },
     "reduce-css-calc": {
       "version": "1.3.0",
@@ -9296,6 +9394,14 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rtl-css-js": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.11.0.tgz",
+      "integrity": "sha512-YnZ6jWxZxlWlcQAGF9vOmiF9bEmoQmSHE+wsrsiILkdK9HqiRPAIll4SY/QDzbvEu2lB2h62+hfg3TYzjnldbA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "run-async": {
@@ -9693,6 +9799,11 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "sourcemap-codec": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
+      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA=="
+    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -9744,6 +9855,45 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
+    },
+    "stack-generator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
+      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+      "requires": {
+        "stackframe": "^1.0.4"
+      }
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.0.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
+      "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
+      "requires": {
+        "error-stack-parser": "^2.0.1",
+        "stack-generator": "^2.0.1",
+        "stacktrace-gps": "^3.0.1"
+      }
     },
     "static-eval": {
       "version": "2.0.0",
@@ -10048,6 +10198,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "throttle-debounce": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.0.1.tgz",
+      "integrity": "sha512-Sr6jZBlWShsAaSXKyNXyNicOrJW/KtkDqIEwHt4wYwWA2wa/q67Luhqoujg48V8hTk60wB56tYrJJn6jc2R7VA=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -10181,6 +10336,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "ts-easing": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.1.1.tgz",
+      "integrity": "sha512-0ak4XidpHPzrGFShdgKWY70EyShH/jKUARsJD7GjmQDmHVWxnuIzhN+B2aCqB/0lp/QGSbuk1rOXxQasRc5yiA=="
     },
     "tslib": {
       "version": "1.9.3",
@@ -10393,6 +10553,19 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-callbag": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/use-callbag/-/use-callbag-0.1.2.tgz",
+      "integrity": "sha512-8JJIpoqQaqJu9nfSTYe4WpJm2NyfHYgIDjouxhu4WOpgYI8W9IvMM32ecfcdZTzkWDuZkEyh3unGLMxA4wF7Bg==",
+      "requires": {
+        "callbag-subscribe": "^1.4.1"
+      }
+    },
+    "use-onclickoutside": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/use-onclickoutside/-/use-onclickoutside-0.1.1.tgz",
+      "integrity": "sha512-IcQzKjG9OAlMQBGmUZ/3pU6DUuynPb6KlZaGNOFdmJ0FaV1yhJLauvvPcTerWAuH84K/cbkOLyAgncY+oTLtcg=="
     },
     "util": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-select": "2.1.1",
     "react-svg-inline": "2.1.1",
     "react-toggle": "4.0.2",
+    "react-use": "4.10.0",
     "react-use-promise": "0.0.0-alpha.1",
     "shifty": "2.6.1",
     "shortid": "2.2.14",

--- a/src/dashboard/high-score.jsx
+++ b/src/dashboard/high-score.jsx
@@ -84,7 +84,7 @@ yet!
       .map((r, i) => {
         const classes = [r[0].qText === player.userid ? 'me' : ''];
         return (
-          <tr key={r[0].qText + r[2].qNum + distinct} className={classes}>
+          <tr key={r[0].qText + r[3].qNum + distinct} className={classes}>
             <td>{i + 1}</td>
             <td>{r[1].qText}</td>
             <td>{r[2].qText}</td>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,11 +2,13 @@ import '@babel/polyfill';
 
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
+import { useIdle } from 'react-use';
 
 import useSocket from './hooks/socket';
 import usePlayer from './hooks/player';
 import ErrorBoundary from './error-boundary';
 import Header from './header';
+import Overlay from './overlay';
 import Dashboard from './dashboard/layout';
 import Engine from './game/engine';
 
@@ -22,6 +24,7 @@ function Index() {
   const player = usePlayer(socket);
   const [previousPlayer, setPreviousPlayer] = useState({});
   const [isStarted, setIsStarted] = useState(false);
+  const isIdle = useIdle(30000);
 
   useEffect(() => {
     if (player.userid === previousPlayer.userid) {
@@ -42,6 +45,7 @@ function Index() {
     <div className="index">
       <Header player={player} socket={socket} />
       {view}
+      {!isStarted && isIdle ? <Overlay /> : null}
     </div>
   );
 }

--- a/src/overlay.css
+++ b/src/overlay.css
@@ -1,0 +1,37 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #9f99d9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  opacity: 0.9;
+}
+
+.overlay .text {
+  font-size: 3rem;
+  text-shadow: 0 0 3px #333;
+  color: white;
+}
+
+@keyframes moveX {
+  0% { background-position-x: 0px; }
+  25% { background-position-x: 96px; }
+  50% { background-position-x: 192px; }
+  75% { background-position-x: 288px; }
+  100% { background-position-x: 384px; }
+}
+
+.overlay .animation {
+  margin-top: 200px;
+  width: 96px;
+  height: 32px;
+  background: url('./resources/sprites/chopper_v2.png') left center;
+  animation: 16ms moveX infinite;
+  animation-timing-function:steps(1);
+  transform: scale(5) rotate(10deg);
+}

--- a/src/overlay.jsx
+++ b/src/overlay.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import './overlay.css';
+
+export default function () {
+  return (
+    <section className="overlay">
+      <div className="text">Fly the chopper, win a prize!</div>
+      <div className="animation" />
+    </section>
+  );
+}


### PR DESCRIPTION
Adds an overlay to the dashboard when there's been no activity for 60 seconds, removed as soon as there's activity (e.g. mousemove). The chopper is animated.

Text and size of it can be easily changed (hint hint tomorrow @JohanBjerning)

<img width="1379" alt="screen shot 2018-11-18 at 6 28 09 pm" src="https://user-images.githubusercontent.com/83221/48676094-136c7f00-eb62-11e8-96ac-98a4969ea4a5.png">
